### PR TITLE
fix: Fix caret color for iOS

### DIFF
--- a/src/cozy/_forms.scss
+++ b/src/cozy/_forms.scss
@@ -17,6 +17,10 @@
   border-radius: 50%;
 }
 
+.form-control {
+  caret-color: var(--primaryColor);
+}
+
 .form-control:hover {
   border-color: var(--primaryColor);
 }


### PR DESCRIPTION
On mobile, the cursor is not visible on Safari for inputs, with the
inverted theme.