### PR TITLE
fix: Remove minimal version of node for the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,5 @@
     "stylelint": "14.1.0",
     "stylelint-config-twbs-bootstrap": "3.0.1",
     "vnu-jar": "21.10.12"
-  },
-  "engines": {
-    "node": ">=14"
   }
 }


### PR DESCRIPTION
Version 14 of Node is only required for CI and development. I made a mistake by adding this argument as cozy-site use node 8 and node minimal ins't required for dist 